### PR TITLE
Update action.yml to handle the Hedera version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ The GitHub action takes the following inputs:
 - `installMirrorNode`: A boolean parameter that is `false` by default.
   If set to `true`, the action will install a mirror node in addition to the main node.
   The mirror node can be accessed at `localhost:8080`.
-
-| Input          | Description                   | Required | Default |
-|----------------|-------------------------------|----------|---------|
-| `installRelay` | Install JSON-RPC-Relay        | false    | false   |
-
 - `installRelay`: A boolean parameter that is `false` by default.
-  If set to `true`, the action will install the JSON-RPC-Relay as part of the setup process. This allows you to easily add a relay to your Hedera network setup. The relay is installed using the `solo relay deploy` command.
+  If set to `true`, the action will install the JSON-RPC-Relay as part of the setup process. This allows you to easily add a relay to your Hedera network setup. The relay is 
+  installed using the `solo relay deploy` command.
+
+| Input          | Description                    | Required | Default   |
+|----------------|--------------------------------|----------|-----------|
+| `installRelay` | Install JSON-RPC-Relay         | false    | false     |
+| `hederaVersion`| Hedera network version to use  | false    | `v0.52.2` |   
+
+- `hederaVersion`: An optional parameter to specify the Hedera version used in the setup.
+  If not provided, the action defaults to the latest Mainnet version (v0.52.2).
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: true
     default: false
     type: boolean
+  hederaVersion: 
+    description: 'Version of Hedera to use. Defaults to Mainnet version.'
+    required: false
+    default: 'v0.52.2' 
 outputs:
   accountId:
     description: "Hedera account id for a new account"

--- a/action.yml
+++ b/action.yml
@@ -1,19 +1,19 @@
-name: 'Hedera Solo'
-description: 'Run a Hedera Solo network'
+name: "Hedera Solo"
+description: "Run a Hedera Solo network"
 inputs:
   installMirrorNode:
-    description: 'Defines if a mirror node should be installed'
+    description: "Defines if a mirror node should be installed"
     required: true
     default: false
     type: boolean
-  hederaVersion: 
-    description: 'Version of Hedera to use. Defaults to Mainnet version.'
+  hederaVersion:
+    description: "Version of Hedera to use. Defaults to Mainnet version."
     required: false
-    default: 'v0.52.2' 
-  mirrorNodePort : 
-    description : 'Port for Mirror Node' 
-    required: false  
-    default : '8080'
+    default: "v0.52.2"
+  mirrorNodePort:
+    description: "Port for Mirror Node"
+    required: false
+    default: "8080"
 outputs:
   accountId:
     description: "Hedera account id for a new account"
@@ -51,7 +51,7 @@ runs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: "3.10"
 
     - name: Setup Kind
       uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
@@ -68,7 +68,7 @@ runs:
     - name: Deploy Solo Test Network
       shell: bash
       run: |
-        solo init -i node0 -t v0.51.5 -n solo-test --key-format pem --profile local
+        solo init -i node0 -t ${{ inputs.hederaVersion }} -n solo-test --key-format pem --profile local
         solo cluster setup
         solo node keys --tls-keys --gossip-keys
         solo network deploy
@@ -103,5 +103,5 @@ runs:
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 branding:
-  icon: 'share-2'
-  color: 'black'
+  icon: "share-2"
+  color: "black"


### PR DESCRIPTION
Fixes issue #4
**Added Optional Input Parameter:**

1. Introduced hederaVersion as an optional input parameter in the action's metadata.
2. The default value for this parameter is set to the current Mainnet version (v0.52.2), ensuring compatibility with the latest release.